### PR TITLE
feat: 新增可选的 TwelveLabs 供应商（Pegasus 视频理解 + Marengo 多模态向量）/ Add opt-in TwelveLabs provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ docker-compose -f docker-compose.prod.yml up -d
 - 前端 API 密钥管理页：`frontend/src/views/APIKeys.vue`
 - 前端设置页 API 密钥面板：`frontend/src/views/settings/APIKeysSettings.vue`
 
+### 3.1 可选：TwelveLabs 视频理解 / 多模态向量
+
+项目内置了一个 **可选** 的 [TwelveLabs](https://twelvelabs.io) 供应商，用于视频理解与素材检索，完全不影响现有行为——不配置 TwelveLabs API Key 时系统一切照旧。
+
+- **Pegasus（视频理解）**：对成片或素材视频做内容分析，可用于自动生成分镜描述、镜头摘要、内容审核等创作辅助。
+- **Marengo（多模态向量）**：为视频 / 文本生成 512 维向量，可用于素材库语义检索、画布节点之间的素材匹配与去重。
+
+配置方式与其它供应商一致：在“API 密钥管理”页面新增一条 `provider = twelvelabs` 的密钥即可。免费额度可在 https://twelvelabs.io 获取。
+
+相关代码位置：
+
+- 后端供应商封装：`backend/src/services/provider/twelvelabs_provider.py`
+- 单元 / 集成测试：`backend/tests/unit/test_twelvelabs_provider.py`
+
 ### 4. 开始创作
 
 基本流程如下：

--- a/backend/src/api/schemas/api_key.py
+++ b/backend/src/api/schemas/api_key.py
@@ -21,7 +21,7 @@ class APIKeyCreate(BaseModel):
     @classmethod
     def validate_provider(cls, v: str) -> str:
         """验证服务提供商"""
-        valid_providers = ['openai', 'azure', 'google', 'baidu', 'alibaba', 'volcengine', 'custom', 'deepseek','siliconflow']
+        valid_providers = ['openai', 'azure', 'google', 'baidu', 'alibaba', 'volcengine', 'custom', 'deepseek','siliconflow','twelvelabs']
         if v.lower() not in valid_providers:
             raise ValueError(f"无效的服务提供商。支持的提供商: {', '.join(valid_providers)}")
         return v.lower()

--- a/backend/src/models/api_key.py
+++ b/backend/src/models/api_key.py
@@ -34,6 +34,7 @@ class APIKeyProvider(str, Enum):
     VOLCENGINE = "volcengine"
     CUSTOM = "custom"
     SILICONFLOW = "siliconflow"
+    TWELVELABS = "twelvelabs"
 
 
 class APIKey(BaseModel):

--- a/backend/src/services/api_key.py
+++ b/backend/src/services/api_key.py
@@ -369,7 +369,14 @@ class APIKeyService(BaseService):
                 return ['gemini-1.5-pro', 'gemini-1.5-flash']
             elif model_type == "image":
                 return ['imagen-3']
-        
+
+        # TwelveLabs - 视频理解(Pegasus) 与 多模态向量(Marengo)
+        elif provider == 'twelvelabs':
+            if model_type == "video":
+                return ['pegasus1.5']
+            elif model_type == "embedding":
+                return ['marengo3.0']
+
         return []
 
 

--- a/backend/src/services/provider/factory.py
+++ b/backend/src/services/provider/factory.py
@@ -29,5 +29,8 @@ class ProviderFactory:
             case "vectorengine":
                 from .vector_engine_provider import VectorEngineProvider
                 return VectorEngineProvider(api_key, kwargs.get("base_url", "https://api.vectorengine.ai/v1")) # type: ignore
+            case "twelvelabs":
+                from .twelvelabs_provider import TwelveLabsProvider
+                return TwelveLabsProvider(api_key, kwargs.get("base_url", "https://api.twelvelabs.io/v1.3")) # type: ignore
             case _:
                 raise ValueError(f"未知 provider: {provider}")

--- a/backend/src/services/provider/twelvelabs_provider.py
+++ b/backend/src/services/provider/twelvelabs_provider.py
@@ -1,0 +1,156 @@
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from src.core.logging import get_logger
+from src.services.provider.base import log_provider_call
+
+logger = get_logger(__name__)
+
+
+class TwelveLabsProvider:
+    """
+    TwelveLabs API 提供商 (api.twelvelabs.io)
+
+    面向视频理解的可选 Provider：
+    - Pegasus: 对视频做内容理解 / 分析（analyze），用于自动生成分镜描述、
+      镜头摘要、内容审核等创作辅助。
+    - Marengo: 生成视频 / 文本的多模态向量（512 维），用于素材检索、
+      画布节点之间的语义匹配与去重。
+
+    与其它 Provider 一样，这是一个纯粹的 HTTP wrapper，不含任何业务逻辑，
+    完全可选：未配置 TwelveLabs API Key 时系统行为不变。
+    免费 API Key 可在 https://twelvelabs.io 获取。
+    """
+
+    # REST 端点要求 multipart/form-data；Marengo 向量在响应里的字段名是 'float'。
+    DEFAULT_EMBED_MODEL = "marengo3.0"
+    DEFAULT_ANALYZE_MODEL = "pegasus1.5"
+
+    def __init__(self, api_key: str, base_url: str = "https://api.twelvelabs.io/v1.3"):
+        self.api_key = api_key
+        # 规范化 base_url: 去掉结尾斜杠，便于拼接
+        self.base_url = base_url.rstrip("/")
+        self.headers = {"x-api-key": api_key}
+        # 视频处理可能较慢，给足超时
+        self.timeout = httpx.Timeout(300.0, connect=20.0)
+
+    @log_provider_call("embed_text")
+    async def embed_text(
+        self,
+        text: str,
+        model: str = DEFAULT_EMBED_MODEL,
+        **kwargs: Any,
+    ) -> List[float]:
+        """
+        使用 Marengo 生成文本的多模态向量（512 维）。
+
+        注意：/v1.3/embed 即使是纯文本请求也要求 multipart/form-data；
+        因此这里用 files=（(None, value) 元组）强制 httpx 走 multipart 编码，
+        而不是默认的 x-www-form-urlencoded。
+        """
+        url = f"{self.base_url}/embed"
+        fields = {"model_name": model, "text": text}
+        fields.update(kwargs)
+        files = {k: (None, str(v)) for k, v in fields.items()}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.post(url, headers=self.headers, files=files)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                logger.error(f"TwelveLabs Embed Failed: {e.response.text}")
+                raise
+            except Exception as e:
+                logger.error(f"TwelveLabs Embed Error: {e}")
+                raise
+
+        return _extract_embedding(response.json())
+
+    @log_provider_call("embed_video")
+    async def embed_video(
+        self,
+        video_url: str,
+        model: str = DEFAULT_EMBED_MODEL,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        使用 Marengo 为视频创建向量任务（异步）。
+
+        返回任务信息（含 task id），实际向量需轮询 /embed/tasks/{id}/status 获取。
+        公开 URL 最大支持 4GB。/v1.3/embed 同样要求 multipart/form-data。
+        """
+        url = f"{self.base_url}/embed/tasks"
+        fields = {"model_name": model, "video_url": video_url}
+        fields.update(kwargs)
+        files = {k: (None, str(v)) for k, v in fields.items()}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.post(url, headers=self.headers, files=files)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                logger.error(f"TwelveLabs Embed Video Failed: {e.response.text}")
+                raise
+            except Exception as e:
+                logger.error(f"TwelveLabs Embed Video Error: {e}")
+                raise
+
+    @log_provider_call("analyze")
+    async def analyze(
+        self,
+        prompt: str,
+        video_url: Optional[str] = None,
+        asset_id: Optional[str] = None,
+        model: str = DEFAULT_ANALYZE_MODEL,
+        max_tokens: int = 2048,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        使用 Pegasus 对视频做内容理解 / 分析。
+
+        Pegasus 1.5 不接受裸 video_id，必须提供公开 URL 或已上传的 asset_id；
+        被分析的视频时长需 >= 4 秒，max_tokens 取值范围 512~98304。
+        本地文件上传（assets, method=direct）上限 200MB，公开 URL 上限 4GB。
+        """
+        if not video_url and not asset_id:
+            raise ValueError("必须提供 video_url 或 asset_id 之一")
+
+        if video_url:
+            video: Dict[str, Any] = {"type": "url", "url": video_url}
+        else:
+            video = {"type": "asset_id", "asset_id": asset_id}
+
+        url = f"{self.base_url}/analyze"
+        payload = {
+            "model_name": model,
+            "video": video,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+        }
+        payload.update(kwargs)
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.post(url, headers=self.headers, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPStatusError as e:
+                logger.error(f"TwelveLabs Analyze Failed: {e.response.text}")
+                raise
+            except Exception as e:
+                logger.error(f"TwelveLabs Analyze Error: {e}")
+                raise
+
+
+def _extract_embedding(payload: Dict[str, Any]) -> List[float]:
+    """从 /v1.3/embed 响应中提取文本向量。REST 原始字段名为 'float'。"""
+    segments = (payload.get("text_embedding") or {}).get("segments") or []
+    if not segments:
+        raise ValueError(f"TwelveLabs 响应中未找到向量: {payload}")
+    first = segments[0]
+    vector = first.get("float") or first.get("float_") or first.get("embedding")
+    if not vector:
+        raise ValueError(f"TwelveLabs 向量字段为空: {first}")
+    return vector

--- a/backend/tests/unit/test_twelvelabs_provider.py
+++ b/backend/tests/unit/test_twelvelabs_provider.py
@@ -1,0 +1,108 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.provider.factory import ProviderFactory
+from src.services.provider.twelvelabs_provider import (
+    TwelveLabsProvider,
+    _extract_embedding,
+)
+
+
+class TestTwelveLabsProvider:
+    def test_factory_creates_provider(self):
+        provider = ProviderFactory.create("twelvelabs", api_key="test-key")
+        assert isinstance(provider, TwelveLabsProvider)
+        assert provider.headers["x-api-key"] == "test-key"
+        # base_url 应去掉结尾斜杠
+        assert provider.base_url == "https://api.twelvelabs.io/v1.3"
+
+    def test_extract_embedding_uses_rest_float_key(self):
+        # REST /v1.3/embed 原始字段名是 'float'，且向量为 512 维
+        payload = {"text_embedding": {"segments": [{"float": [0.1] * 512}]}}
+        vector = _extract_embedding(payload)
+        assert len(vector) == 512
+
+    def test_extract_embedding_raises_on_empty(self):
+        with pytest.raises(ValueError):
+            _extract_embedding({"text_embedding": {"segments": []}})
+
+    @pytest.mark.asyncio
+    async def test_embed_text_posts_multipart_form_data(self):
+        provider = TwelveLabsProvider(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "text_embedding": {"segments": [{"float": [0.0] * 512}]}
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch(
+            "src.services.provider.twelvelabs_provider.httpx.AsyncClient"
+        ) as client_cls:
+            client_cls.return_value.__aenter__.return_value = mock_client
+            vector = await provider.embed_text("a dramatic sunset")
+
+        assert len(vector) == 512
+        _, kwargs = mock_client.post.call_args
+        # /v1.3/embed 必须用 multipart/form-data：用 files=（(None, value) 元组）
+        # 强制 httpx 走 multipart，而不是 json= 或默认的 urlencoded
+        assert "files" in kwargs and "json" not in kwargs
+        files = kwargs["files"]
+        assert files["model_name"] == (None, "marengo3.0")
+        assert files["text"] == (None, "a dramatic sunset")
+
+    @pytest.mark.asyncio
+    async def test_analyze_requires_a_video_source(self):
+        provider = TwelveLabsProvider(api_key="test-key")
+        with pytest.raises(ValueError):
+            await provider.analyze(prompt="describe")
+
+    @pytest.mark.asyncio
+    async def test_analyze_builds_url_video_payload(self):
+        provider = TwelveLabsProvider(api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": "a clip of an ocean sunset"}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch(
+            "src.services.provider.twelvelabs_provider.httpx.AsyncClient"
+        ) as client_cls:
+            client_cls.return_value.__aenter__.return_value = mock_client
+            result = await provider.analyze(
+                prompt="Describe this video.",
+                video_url="https://example.com/clip.mp4",
+            )
+
+        assert result["data"] == "a clip of an ocean sunset"
+        _, kwargs = mock_client.post.call_args
+        payload = kwargs["json"]
+        assert payload["model_name"] == "pegasus1.5"
+        assert payload["video"] == {
+            "type": "url",
+            "url": "https://example.com/clip.mp4",
+        }
+        # Pegasus 1.5 要求 max_tokens 在 512~98304 之间
+        assert payload["max_tokens"] >= 512
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="需要 TWELVELABS_API_KEY 环境变量才能进行真实 API 调用",
+)
+class TestTwelveLabsProviderLive:
+    @pytest.mark.asyncio
+    async def test_marengo_text_embedding_is_512_dim(self):
+        provider = TwelveLabsProvider(api_key=os.environ["TWELVELABS_API_KEY"])
+        vector = await provider.embed_text("a dramatic sunset over the ocean")
+        assert len(vector) == 512
+        assert all(isinstance(x, (int, float)) for x in vector)

--- a/frontend/src/services/apiKeys.js
+++ b/frontend/src/services/apiKeys.js
@@ -103,7 +103,8 @@ export const apiKeyUtils = {
             'alibaba': '阿里云',
             'volcengine': '火山引擎',
             'custom': '自定义',
-            'siliconflow': 'SiliconFlow'
+            'siliconflow': 'SiliconFlow',
+            'twelvelabs': 'TwelveLabs'
         }
         return providerMap[provider] || provider
     },
@@ -150,7 +151,8 @@ export const apiKeyUtils = {
             'alibaba': 'Cloudy',
             'volcengine': 'Cloudy',
             'custom': 'Setting',
-            'siliconflow': 'Cloudy'
+            'siliconflow': 'Cloudy',
+            'twelvelabs': 'VideoCamera'
         }
         return iconMap[provider] || 'Key'
     },
@@ -196,6 +198,7 @@ export const apiKeyUtils = {
             // { label: '火山引擎', value: 'volcengine' },
             // { label: 'deepseek', value: 'deepseek' },
             { label: '硅基流动', value: 'siliconflow' },
+            { label: 'TwelveLabs (视频理解 / 向量)', value: 'twelvelabs' },
             { label: '自定义', value: 'custom' }
         ]
     },


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## 简介（中文）

为项目新增一个 **完全可选** 的 [TwelveLabs](https://twelvelabs.io) 视频理解供应商，沿用现有的 provider 工厂模式，不改变任何默认行为——不配置 TwelveLabs API Key 时系统一切照旧。

- **Pegasus（视频理解 / analyze）**：对成片或素材做内容分析，可用于自动生成分镜描述、镜头摘要、内容审核等创作辅助。
- **Marengo（多模态向量 / embed）**：为视频与文本生成 512 维向量，可用于素材库语义检索、画布节点之间的素材匹配与去重。

配置方式与其它供应商一致：在“API 密钥管理”页面新增一条 `provider = twelvelabs` 的密钥即可。免费额度可在 https://twelvelabs.io 获取。

## What this adds (English)

A new **opt-in** TwelveLabs provider that plugs into the existing `ProviderFactory` pattern, mirroring `VectorEngineProvider` (httpx-based, same `log_provider_call` decorator and Chinese docstrings/logging style):

- `backend/src/services/provider/twelvelabs_provider.py`
  - `analyze(...)` — **Pegasus** video understanding (accepts a public `video_url` or an uploaded `asset_id`; Pegasus 1.5 does not accept a bare `video_id`).
  - `embed_text(...)` / `embed_video(...)` — **Marengo** 512-dim multimodal embeddings.
- Wired into `ProviderFactory.create("twelvelabs", ...)`, the provider validation whitelist + `APIKeyProvider` enum, and `APIKeyService.get_models` (`pegasus1.5` for video, `marengo3.0` for embeddings).
- Frontend: `twelvelabs` option added to the API Key management dropdown / label / icon maps.

## Why it helps this project

AICON is a node-based AI video creation workflow. Pegasus gives the canvas a way to *understand* generated/imported clips (auto shot descriptions, summaries, moderation), and Marengo gives semantic asset retrieval/dedup across canvas nodes — both natural extensions of the existing storyboard/asset pipeline.

## Opt-in / non-breaking

This is purely additive. No defaults change; if no TwelveLabs key is configured, behavior is identical to before. It reads its own API key from the repo's existing per-user, DB-backed API Key management (encrypted) — no key is hardcoded.

## How it was tested

- No-network unit tests for the factory wiring, the multipart `embed` encoding, the Pegasus payload shape, and the embedding extraction (`backend/tests/unit/test_twelvelabs_provider.py`) — **6 passed**.
- A live integration test gated on `TWELVELABS_API_KEY` (skipped when unset). I ran it against the real API and confirmed a Marengo text embedding returns a **512-dim** vector — **passed**.
- I live-verified both REST contracts against `api.twelvelabs.io/v1.3`: Marengo `marengo3.0` requires `multipart/form-data` (even for text-only; raw vector key is `float`), and Pegasus `pegasus1.5` accepts `video: {type, url}` with `max_tokens >= 512`.
- Ran `black` / `isort` on the new files only (kept the diff minimal — existing files were edited surgically, not reformatted).

Note: my local macOS sandbox couldn't load `libmagic` (a pre-existing dependency of an unrelated conftest import chain), so I ran the focused TwelveLabs tests with a tiny `magic` stub injected; they pass cleanly. The full suite should run normally in your CI/Linux env where libmagic is present.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
