### PR TITLE
feat(provider): add Atlas Cloud support

### DIFF
--- a/backend/src/api/schemas/api_key.py
+++ b/backend/src/api/schemas/api_key.py
@@ -21,7 +21,10 @@ class APIKeyCreate(BaseModel):
     @classmethod
     def validate_provider(cls, v: str) -> str:
         """验证服务提供商"""
-        valid_providers = ['openai', 'azure', 'google', 'baidu', 'alibaba', 'volcengine', 'custom', 'deepseek','siliconflow']
+        valid_providers = [
+            'openai', 'azure', 'google', 'baidu', 'alibaba', 'volcengine',
+            'custom', 'deepseek', 'siliconflow', 'atlascloud'
+        ]
         if v.lower() not in valid_providers:
             raise ValueError(f"无效的服务提供商。支持的提供商: {', '.join(valid_providers)}")
         return v.lower()

--- a/backend/src/models/api_key.py
+++ b/backend/src/models/api_key.py
@@ -34,6 +34,7 @@ class APIKeyProvider(str, Enum):
     VOLCENGINE = "volcengine"
     CUSTOM = "custom"
     SILICONFLOW = "siliconflow"
+    ATLASCLOUD = "atlascloud"
 
 
 class APIKey(BaseModel):

--- a/backend/src/services/api_key.py
+++ b/backend/src/services/api_key.py
@@ -364,6 +364,10 @@ class APIKeyService(BaseService):
             if model_type == "text":
                 return ['deepseek-chat', 'deepseek-reasoner']
 
+        elif provider == 'atlascloud':
+            if model_type == "text":
+                return ['deepseek-ai/deepseek-v4-pro']
+
         elif provider == 'google':
             if model_type == "text":
                 return ['gemini-1.5-pro', 'gemini-1.5-flash']

--- a/backend/src/services/provider/factory.py
+++ b/backend/src/services/provider/factory.py
@@ -26,6 +26,12 @@ class ProviderFactory:
             case "custom":
                 return CustomProvider(api_key, kwargs.get("max_concurrency", 5),
                                       kwargs.get("base_url", "https://api.aiconapi.me/v1"))
+            case "atlascloud":
+                return CustomProvider(
+                    api_key,
+                    kwargs.get("max_concurrency", 5),
+                    kwargs.get("base_url") or "https://api.atlascloud.ai/v1",
+                )
             case "vectorengine":
                 from .vector_engine_provider import VectorEngineProvider
                 return VectorEngineProvider(api_key, kwargs.get("base_url", "https://api.vectorengine.ai/v1")) # type: ignore

--- a/backend/tests/unit/test_atlascloud_provider.py
+++ b/backend/tests/unit/test_atlascloud_provider.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+from src.services.provider.custom_provider import CustomProvider
+from src.services.provider.factory import ProviderFactory
+
+
+def test_factory_uses_atlascloud_openai_compatible_endpoint():
+    with patch("src.services.provider.custom_provider.AsyncOpenAI") as openai:
+        provider = ProviderFactory.create("atlascloud", "test-key")
+
+    assert isinstance(provider, CustomProvider)
+    assert provider.base_url == "https://api.atlascloud.ai/v1"
+    openai.assert_called_once_with(
+        api_key="test-key",
+        base_url="https://api.atlascloud.ai/v1",
+    )

--- a/frontend/src/services/apiKeys.js
+++ b/frontend/src/services/apiKeys.js
@@ -103,7 +103,8 @@ export const apiKeyUtils = {
             'alibaba': '阿里云',
             'volcengine': '火山引擎',
             'custom': '自定义',
-            'siliconflow': 'SiliconFlow'
+            'siliconflow': 'SiliconFlow',
+            'atlascloud': 'Atlas Cloud'
         }
         return providerMap[provider] || provider
     },
@@ -150,7 +151,8 @@ export const apiKeyUtils = {
             'alibaba': 'Cloudy',
             'volcengine': 'Cloudy',
             'custom': 'Setting',
-            'siliconflow': 'Cloudy'
+            'siliconflow': 'Cloudy',
+            'atlascloud': 'Cloudy'
         }
         return iconMap[provider] || 'Key'
     },
@@ -196,8 +198,16 @@ export const apiKeyUtils = {
             // { label: '火山引擎', value: 'volcengine' },
             // { label: 'deepseek', value: 'deepseek' },
             { label: '硅基流动', value: 'siliconflow' },
+            { label: 'Atlas Cloud', value: 'atlascloud' },
             { label: '自定义', value: 'custom' }
         ]
+    },
+
+    getProviderDefaultBaseUrl(provider) {
+        const baseUrlMap = {
+            'atlascloud': 'https://api.atlascloud.ai/v1'
+        }
+        return baseUrlMap[provider] || 'https://api.aiconapi.me/v1'
     },
 
     /**

--- a/frontend/src/views/APIKeys.vue
+++ b/frontend/src/views/APIKeys.vue
@@ -132,6 +132,7 @@
             placeholder="请选择服务提供商"
             :disabled="isEdit"
             style="width: 100%"
+            @change="handleProviderChange"
           >
             <el-option
               v-for="provider in apiKeyUtils.getProviderOptions()"
@@ -263,6 +264,10 @@ const showAddDialog = () => {
   if (formRef.value) {
     formRef.value.clearValidate()
   }
+}
+
+const handleProviderChange = (provider) => {
+  formData.base_url = apiKeyUtils.getProviderDefaultBaseUrl(provider)
 }
 
 // 显示编辑对话框

--- a/frontend/src/views/settings/APIKeysSettings.vue
+++ b/frontend/src/views/settings/APIKeysSettings.vue
@@ -132,6 +132,7 @@
             placeholder="请选择服务提供商"
             :disabled="isEdit"
             style="width: 100%"
+            @change="handleProviderChange"
           >
             <el-option
               v-for="provider in apiKeyUtils.getProviderOptions()"
@@ -263,6 +264,10 @@ const showAddDialog = () => {
   if (formRef.value) {
     formRef.value.clearValidate()
   }
+}
+
+const handleProviderChange = (provider) => {
+  formData.base_url = apiKeyUtils.getProviderDefaultBaseUrl(provider)
 }
 
 // 显示编辑对话框


### PR DESCRIPTION
## Summary
- add Atlas Cloud to the API key provider registry with `https://api.atlascloud.ai/v1` as its default OpenAI-compatible endpoint
- expose the provider in both API key settings views and default to `deepseek-ai/deepseek-v4-pro`
- route Atlas Cloud through the existing `CustomProvider` implementation and cover the factory endpoint contract

## Validation
- `pytest backend/tests/unit/test_atlascloud_provider.py backend/tests/unit/test_custom_provider.py`: 2 passed
- `npm run build`: passed
- Python 3.11 `compileall`: passed
- Atlas model catalog: HTTP 200 and default model present
- Atlas chat completions live probe: HTTP 200
- targeted ESLint could not start because the repository config references the undeclared `@vue/eslint-config-prettier` package

## Scope
No README, documentation, logo, sponsor, credits, or partner promotion changes.
